### PR TITLE
Fix profile section syntax errors

### DIFF
--- a/src/components/settings/contexts/SettingsContext.tsx
+++ b/src/components/settings/contexts/SettingsContext.tsx
@@ -177,6 +177,7 @@ function settingsReducer(
     default:
       return state;
   }
+}
 interface SettingsProviderProps {
   children: React.ReactNode;
 }


### PR DESCRIPTION
Fix build errors by restoring missing local state, functions, and correcting syntax in `ProfileSection.tsx`, and adding a missing brace in `SettingsContext.tsx`.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a75885b-9d34-4f6e-94f0-c7ca90b254db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4a75885b-9d34-4f6e-94f0-c7ca90b254db">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

