### PR TITLE
Changes from background agent bc-94f0b269-c616-45a9-b58c-d8153138cfde

### DIFF
--- a/src/components/settings/contexts/SettingsContext.tsx
+++ b/src/components/settings/contexts/SettingsContext.tsx
@@ -622,3 +622,5 @@ export const SettingsProvider: React.FC<SettingsProviderProps> = ({ children }) 
     </SettingsContext.Provider>
   );
 };
+
+export default SettingsProvider;

--- a/src/components/settings/sections/ProfileSection.tsx
+++ b/src/components/settings/sections/ProfileSection.tsx
@@ -16,8 +16,6 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
   const [localEditData, setLocalEditData] = useState(settings.profile);
   const [editingField, setEditingField] = useState<string | null>(null);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [localEditData, setLocalEditData] = useState<UserProfile | null>(null);
-
 
   // 프로필 완성도 계산 최적화
   const profileCompletion = useMemo(() => {
@@ -40,6 +38,8 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
       { key: 'location', label: '위치', icon: MapPin },
       { key: 'bio', label: '자기소개', icon: Globe },
     ];
+    
+    return fields.filter(field => !settings.profile[field.key as keyof typeof settings.profile]);
   }, [settings.profile]);
 
   const handleEditToggle = () => {
@@ -64,6 +64,9 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
       console.error('프로필 저장 실패:', error);
     }
   };
+
+  const handleFieldEdit = (fieldKey: string) => {
+    setEditingField(fieldKey);
   };
 
   if (!isActive) return null;


### PR DESCRIPTION
Fix parsing errors in `SettingsContext.tsx` and `ProfileSection.tsx` to allow quality checks to complete.

The `npm run quality:check` command was failing due to parsing errors in these two files, preventing the linting process from completing. This PR resolves a missing export statement in `SettingsContext.tsx` and addresses duplicate variable declarations and missing closing braces in `ProfileSection.tsx`. With these fixes, the quality check now runs successfully, reporting only warnings.

---
<a href="https://cursor.com/background-agent?bcId=bc-94f0b269-c616-45a9-b58c-d8153138cfde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94f0b269-c616-45a9-b58c-d8153138cfde">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

