### PR TITLE
Check project types for errors

### DIFF
--- a/src/components/settings/sections/ProfileSection.tsx
+++ b/src/components/settings/sections/ProfileSection.tsx
@@ -16,7 +16,6 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
   const [localEditData, setLocalEditData] = useState(settings.profile);
   const [editingField, setEditingField] = useState<string | null>(null);
   const [formErrors, setFormErrors] = useState<Record<string, string>>({});
-  const [localEditData, setLocalEditData] = useState<UserProfile | null>(null);
 
 
   // 프로필 완성도 계산 최적화
@@ -40,6 +39,21 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
       { key: 'location', label: '위치', icon: MapPin },
       { key: 'bio', label: '자기소개', icon: Globe },
     ];
+    
+    return fields.filter(field => {
+      switch (field.key) {
+        case 'displayName':
+          return !settings.profile.displayName;
+        case 'phone':
+          return !settings.profile.phone;
+        case 'location':
+          return !settings.profile.location;
+        case 'bio':
+          return !settings.profile.bio;
+        default:
+          return false;
+      }
+    });
   }, [settings.profile]);
 
   const handleEditToggle = () => {
@@ -64,6 +78,10 @@ export const ProfileSection: React.FC<ProfileSectionProps> = ({ isActive }) => {
       console.error('프로필 저장 실패:', error);
     }
   };
+
+  const handleFieldEdit = (fieldKey: string) => {
+    setEditingField(fieldKey);
+    setIsEditing(true);
   };
 
   if (!isActive) return null;


### PR DESCRIPTION
Fix TypeScript error TS1128 in `ProfileSection.tsx` by resolving multiple syntax and type issues.

The original error `TS1128: Declaration or statement expected` was a symptom of several underlying problems in `ProfileSection.tsx`. This PR addresses a duplicate state declaration for `localEditData`, adds a missing return statement to the `incompleteFields` `useMemo` hook, and defines the previously referenced but undefined `handleFieldEdit` function.

---
<a href="https://cursor.com/background-agent?bcId=bc-78ec0313-2067-4a49-a4fc-8b0a7a0ce2d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-78ec0313-2067-4a49-a4fc-8b0a7a0ce2d5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

